### PR TITLE
arducam single

### DIFF
--- a/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/Makefile
+++ b/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/Makefile
@@ -68,6 +68,7 @@ dtbo-y += tegra234-p3740-camera-p3783-a00-overlay.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-ark-imx477-single.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-ark-imx219-single.dtbo
+dtbo-y += tegra234-p3767-camera-p3768-ark-arducam-single.dtbo
 
 ifneq ($(dtb-y),)
 dtb-y := $(addprefix $(makefile-path)/,$(dtb-y))

--- a/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-arducam-single.dts
+++ b/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-arducam-single.dts
@@ -134,18 +134,18 @@
 						skip_mux_detect = "yes";
 						force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
 						i2c@0 {
+							status = "okay";
 							reg = <0>;
 							#address-cells = <1>;
 							#size-cells = <0>;
 							i2c-mux,deselect-on-exit;
-							status = "okay";
 
 							ark_imx219_a@10 {
 								status = "disabled";
 							};
 
 							ark_arducam_a@0c {
-								status = "okay";
+								// status = "okay";
 								reset-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
 								compatible = "arducam,arducam-csi2";
 								reg = <0x0c>;

--- a/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-arducam-single.dts
+++ b/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-arducam-single.dts
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#define CAM0_PWDN	TEGRA234_MAIN_GPIO(H, 6)
+#define CAMERA_I2C_MUX_BUS(x) (0x1E + x)
+
+#include <dt-bindings/tegra234-p3767-0000-common.h>
+#include <dt-bindings/clock/tegra234-clock.h>
+
+/ {
+	overlay-name = "Camera ARK ARDUCAM Single";
+	jetson-header-name = "Jetson 24pin CSI Connector";
+	compatible = JETSON_COMPATIBLE_P3768;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi  {
+				num-channels = <1>;
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					port@0 {
+						reg = <0>;
+						ark_arducam_vi_in0: endpoint {
+							port-index = <0>;
+							bus-width = <2>;
+							remote-endpoint = <&ark_arducam_csi_out0>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				/**
+				* Physical settings to calculate max ISO BW
+				*
+				* num_csi_lanes = <>;
+				* Total number of CSI lanes when all cameras are active
+				*
+				* max_lane_speed = <>;
+				* Max lane speed in Kbit/s
+				*
+				* min_bits_per_pixel = <>;
+				* Min bits per pixel
+				*
+				* vi_peak_byte_per_pixel = <>;
+				* Max byte per pixel for the VI ISO case
+				*
+				* vi_bw_margin_pct = <>;
+				* Vi bandwidth margin in percentage
+				*
+				* max_pixel_rate = <>;
+				* Max pixel rate in Kpixel/s for the ISP ISO case
+				*
+				* isp_peak_byte_per_pixel = <>;
+				* Max byte per pixel for the ISP ISO case
+				*
+				* isp_bw_margin_pct = <>;
+				* Isp bandwidth margin in percentage
+				*/
+				num_csi_lanes = <2>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <10>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <7500000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				/**
+				 * The general guideline for naming badge_info contains 3 parts, and is as follows,
+				 * The first part is the camera_board_id for the module; if the module is in a FFD
+				 * platform, then use the platform name for this part.
+				 * The second part contains the position of the module, ex. "rear" or "front".
+				 * The third part contains the last 6 characters of a part number which is found
+				 * in the module's specsheet from the vendor.
+				 */
+				modules {
+					module0 {
+						badge = "ark_arducam_rear";
+						position = "rear";
+						orientation = "0";
+						drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/i2c@3180000/tca9546@70/i2c@0/ark_arducam_a@0c";
+
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						status = "okay";
+						channel@0 {
+							reg = <0>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ark_arducam_csi_in0: endpoint@0 {
+										port-index = <0>;
+										bus-width = <2>;
+										remote-endpoint = <&ark_arducam_out0>;
+									};
+								};
+								port@1 {
+									reg = <1>;
+									ark_arducam_csi_out0: endpoint@1 {
+										remote-endpoint = <&ark_arducam_vi_in0>;
+									};
+								};
+							};
+						};
+					};
+				};
+				i2c@3180000 {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					tca9546@70 {
+						status = "okay";
+						compatible = "nxp,pca9546";
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <0x70>;
+						i2c-parent = <&cam_i2c>;
+						skip_mux_detect = "yes";
+						force_bus_start = <CAMERA_I2C_MUX_BUS(0)>;
+						i2c@0 {
+							reg = <0>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+							i2c-mux,deselect-on-exit;
+							status = "okay";
+
+							ark_imx219_a@10 {
+								status = "disabled";
+							};
+
+							ark_arducam_a@0c {
+								status = "okay";
+								reset-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+								compatible = "arducam,arducam-csi2";
+								reg = <0x0c>;
+								devnode = "video0";
+								/* Physical dimensions of sensor */
+								physical_w = "3.680";
+								physical_h = "2.760";
+								sensor_model = "arducam-csi2";
+								use_sensor_mode_id = "true";
+
+								/**
+								* ==== Modes ====
+								* A modeX node is required to support v4l2 driver
+								* implementation with NVIDIA camera software stack
+								*
+								* == Signal properties ==
+								*
+								* phy_mode = "";
+								* PHY mode used by the MIPI lanes for this device
+								*
+								* tegra_sinterface = "";
+								* CSI Serial interface connected to tegra
+								* Incase of virtual HW devices, use virtual
+								* For SW emulated devices, use host
+								*
+								* pix_clk_hz = "";
+								* Sensor pixel clock used for calculations like exposure and framerate
+								*
+								* readout_orientation = "0";
+								* Based on camera module orientation.
+								* Only change readout_orientation if you specifically
+								* Program a different readout order for this mode
+								*
+								* == Image format Properties ==
+								*
+								* active_w = "";
+								* Pixel active region width
+								*
+								* active_h = "";
+								* Pixel active region height
+								*
+								* pixel_t = "";
+								* The sensor readout pixel pattern
+								*
+								* line_length = "";
+								* Pixel line length (width) for sensor mode.
+								*
+								* == Source Control Settings ==
+								*
+								* Gain factor used to convert fixed point integer to float
+								* Gain range [min_gain/gain_factor, max_gain/gain_factor]
+								* Gain step [step_gain/gain_factor is the smallest step that can be configured]
+								* Default gain [Default gain to be initialized for the control.
+								*     use min_gain_val as default for optimal results]
+								* Framerate factor used to convert fixed point integer to float
+								* Framerate range [min_framerate/framerate_factor, max_framerate/framerate_factor]
+								* Framerate step [step_framerate/framerate_factor is the smallest step that can be configured]
+								* Default Framerate [Default framerate to be initialized for the control.
+								*     use max_framerate to get required performance]
+								* Exposure factor used to convert fixed point integer to float
+								* For convenience use 1 sec = 1000000us as conversion factor
+								* Exposure range [min_exp_time/exposure_factor, max_exp_time/exposure_factor]
+								* Exposure step [step_exp_time/exposure_factor is the smallest step that can be configured]
+								* Default Exposure Time [Default exposure to be initialized for the control.
+								*     Set default exposure based on the default_framerate for optimal exposure settings]
+								*
+								* gain_factor = ""; (integer factor used for floating to fixed point conversion)
+								* min_gain_val = ""; (ceil to integer)
+								* max_gain_val = ""; (ceil to integer)
+								* step_gain_val = ""; (ceil to integer)
+								* default_gain = ""; (ceil to integer)
+								* Gain limits for mode
+								*
+								* exposure_factor = ""; (integer factor used for floating to fixed point conversion)
+								* min_exp_time = ""; (ceil to integer)
+								* max_exp_time = ""; (ceil to integer)
+								* step_exp_time = ""; (ceil to integer)
+								* default_exp_time = ""; (ceil to integer)
+								* Exposure Time limits for mode (sec)
+								*
+								* framerate_factor = ""; (integer factor used for floating to fixed point conversion)
+								* min_framerate = ""; (ceil to integer)
+								* max_framerate = ""; (ceil to integer)
+								* step_framerate = ""; (ceil to integer)
+								* default_framerate = ""; (ceil to integer)
+								* Framerate limits for mode (fps)
+								*
+								* embedded_metadata_height = "";
+								* Sensor embedded metadata height in units of rows.
+								* If sensor does not support embedded metadata value should be 0.
+								*/
+								mode0 {
+									mclk_khz = "24000";
+									num_lanes = "2";
+									tegra_sinterface = "serial_a";
+									phy_mode = "DPHY";
+									discontinuous_clk = "yes";
+									dpcm_enable = "false";
+									cil_settletime = "0";
+									lane_polarity = "6";
+									active_w = "3264";
+									active_h = "2464";
+									mode_type = "bayer";
+									pixel_phase = "rggb";
+									csi_pixel_bit_depth = "10";
+									readout_orientation = "90";
+									line_length = "3448";
+									inherent_gain = "1";
+									mclk_multiplier = "9.33";
+									pix_clk_hz = "300000000";
+									gain_factor = "16";
+									framerate_factor = "1000000";
+									exposure_factor = "1000000";
+									min_gain_val = "16"; /* 1.00x */
+									max_gain_val = "170"; /* 10.66x */
+									step_gain_val = "1";
+									default_gain = "16"; /* 1.00x */
+									min_hdr_ratio = "1";
+									max_hdr_ratio = "1";
+									min_framerate = "2000000"; /* 2.0 fps */
+									max_framerate = "21000000"; /* 21.0 fps */
+									step_framerate = "1";
+									default_framerate = "21000000"; /* 21.0 fps */
+									min_exp_time = "13"; /* us */
+									max_exp_time = "683709"; /* us */
+									step_exp_time = "1";
+									default_exp_time = "2495"; /* us */
+									embedded_metadata_height = "0";
+								};
+
+								ports {
+									#address-cells = <1>;
+									#size-cells = <0>;
+									port@0 {
+										reg = <0>;
+										ark_arducam_out0: endpoint {
+											port-index = <0>;
+											bus-width = <2>;
+											remote-endpoint = <&ark_arducam_csi_in0>;
+										};
+									};
+								};
+							};
+						};
+					};
+				};
+
+				gpio@2200000 {
+					camera-control-output-high {
+					gpios = <CAM0_PWDN 1>;
+					label = "cam0-pwdn";
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
Adds an overlay for a single arducam camera on CSI0 using the Jetvariety `arducam` driver