### PR TITLE
enable ina3221

### DIFF
--- a/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/nv-platform/tegra234-p3768-0000+p3767-xxxx-nv-common.dtsi
+++ b/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/nv-platform/tegra234-p3768-0000+p3767-xxxx-nv-common.dtsi
@@ -130,10 +130,6 @@
 			status = "okay";
 		};
 
-		i2c@c240000 {
-			status = "okay";
-		};
-
 		hdr40_i2c1: i2c@c250000 {
 			status = "okay";
 		};
@@ -202,29 +198,30 @@
 		// 	};
 		// };
 
-		// i2c@c240000 {
-		// 	status = "okay";
-		// 	ina32211_1_40: ina3221@40 {
-		// 		compatible = "ti,ina3221";
-		// 		reg = <0x40>;
-		// 		#address-cells = <1>;
-		// 		#size-cells = <0>;
-		// 		channel@0 {
-		// 			reg = <0x0>;
-		// 			label = "VDD_IN";
-		// 			shunt-resistor-micro-ohms = <5000>;
-		// 		};
-		// 		channel@1 {
-		// 			reg = <0x1>;
-		// 			label = "VDD_CPU_GPU_CV";
-		// 			shunt-resistor-micro-ohms = <5000>;
-		// 		};
-		// 		channel@2 {
-		// 			reg = <0x2>;
-		// 			label = "VDD_SOC";
-		// 			shunt-resistor-micro-ohms = <5000>;
-		// 		};
-		// 	};
+		i2c@c240000 {
+			status = "okay";
+			ina32211_1_40: ina3221@40 {
+				compatible = "ti,ina3221";
+				reg = <0x40>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				channel@0 {
+					reg = <0x0>;
+					label = "VDD_IN";
+					shunt-resistor-micro-ohms = <5000>;
+				};
+				channel@1 {
+					reg = <0x1>;
+					label = "VDD_CPU_GPU_CV";
+					shunt-resistor-micro-ohms = <5000>;
+				};
+				channel@2 {
+					reg = <0x2>;
+					label = "VDD_SOC";
+					shunt-resistor-micro-ohms = <5000>;
+				};
+			};
+		}
 		// 	fusb301@25 {
 		// 		compatible = "onsemi,fusb301";
 		// 		reg = <0x25>;


### PR DESCRIPTION
It looks like we disabled the ina3221. I didn't realize it was built into the Orin Nano and Orin NX modules themselves. Need to test.